### PR TITLE
Fixed adherence to naming scheme

### DIFF
--- a/src/piece_color.py
+++ b/src/piece_color.py
@@ -1,5 +1,5 @@
 from enum import Enum
 
-class piece_color (Enum):
-    white = 0
-    black = 1
+class Color (Enum):
+    WHITE = 0
+    BLACK = 1


### PR DESCRIPTION
Enums use pascal case, and enum items use full Uppercase