### PR TITLE
MVP 27 / move type enum

### DIFF
--- a/src/move_type.py
+++ b/src/move_type.py
@@ -1,0 +1,40 @@
+from enum import Enum
+
+class MoveType(Enum):
+    # Moves along x/y axis
+    COLLISION_AXIS_TAKE = 11
+    COLLISION_AXIS_MOVE = 12
+
+    # Moves along x/y axis to ungaurded squares
+    PROTECTED_COLLISION_AXIS_TAKE = 13
+    PROTECTED_COLLISION_AXIS_MOVE = 14
+
+
+    # Moves along y = x or y = -x diagonals
+    COLLISION_DIAG_TAKE = 21
+    COLLISION_DIAG_MOVE = 22
+
+    # Moves along y = x or y = -x diagonals to ungaurded squares
+    PROTECTED_COLLISION_DIAG_TAKE = 23
+    PROTECTED_COLLISION_DIAG_MOVE = 24
+
+
+    # Teleporting/leaping moves
+    ABSOLUTE_TAKE = 31
+    ABSOLUTE_MOVE = 32
+
+    # Teleporting/leaping moves to ungaurded squares
+    PROTECTED_ABSOLUTE_TAKE = 33
+    PROTECTED_ABSOLUTE_MOVE = 34
+
+
+    # Special Moves
+    PAWN_EN_PASSANT = 111
+    KING_CASTLE = 121
+
+    
+    def __str__(self):
+        """Overriden to String method
+
+        Returns Enum name such as COLLISION_AXIS_TAKE instead of Number 11"""
+        return f'{self.name}'

--- a/src/move_type.py
+++ b/src/move_type.py
@@ -2,35 +2,17 @@ from enum import Enum
 
 class MoveType(Enum):
     # Moves along x/y axis
-    COLLISION_AXIS_TAKE = 11
-    COLLISION_AXIS_MOVE = 12
-
-    # Moves along x/y axis to ungaurded squares
-    PROTECTED_COLLISION_AXIS_TAKE = 13
-    PROTECTED_COLLISION_AXIS_MOVE = 14
-
+    COLLISION_AXIS = 1
 
     # Moves along y = x or y = -x diagonals
-    COLLISION_DIAG_TAKE = 21
-    COLLISION_DIAG_MOVE = 22
-
-    # Moves along y = x or y = -x diagonals to ungaurded squares
-    PROTECTED_COLLISION_DIAG_TAKE = 23
-    PROTECTED_COLLISION_DIAG_MOVE = 24
-
+    COLLISION_DIAG = 2
 
     # Teleporting/leaping moves
-    ABSOLUTE_TAKE = 31
-    ABSOLUTE_MOVE = 32
-
-    # Teleporting/leaping moves to ungaurded squares
-    PROTECTED_ABSOLUTE_TAKE = 33
-    PROTECTED_ABSOLUTE_MOVE = 34
-
+    ABSOLUTE = 4
 
     # Special Moves
-    PAWN_EN_PASSANT = 111
-    KING_CASTLE = 121
+    PAWN_EN_PASSANT = 8
+    KING_CASTLE = 16
 
     
     def __str__(self):


### PR DESCRIPTION
A Enum that gives us a list of different move types.
Closes #27 